### PR TITLE
Updated command line in RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,11 +4,13 @@ The data served by [WALS Online](https://wals.info) is curated in the GitHub
 repository [cldf-datasets/wals](https://github.com/cldf-datasets/wals).
 Thus, a release of WALS Online is always bound to a release of this repository.
 
-So, assuming `cldf-datasets/wals` has been released on Zenodo, with DOI `<DOI>`
-assigned to it, we
+To create the database With the cldf-datasets/wals repository located
+in `./wals-data`, run
 
-- recreate the web application's database running
-  ```shell script
-  wals-app initdb --doi <DOI> --repos ../../cldf/wals
-  ```
+```shell script
+clld initdb --cldf ./wals-data/cldf/StructureDataset-metadata.json development.ini
+```
+
+- run tests with `pytest .`
+
 - deploy the app running `fab deploy:production` via `appconfig`.


### PR DESCRIPTION
the old command doesn't seem to work anymore (there is no `wals-app` in the PATH of my virtualenv)﻿.

also the `--doi` option doesn't work with the `clld initdb` comand.  instead DOIs seem to be hardcoded in
`./wals3/templates/chages.mako`, `./wals3/templates/dataset/detail_html.mako` and `./wals3/templates/download.mako`.
So maybe one should add a note on updating DOIs in the case of new data releases? (this would apply to other apps, too)
